### PR TITLE
Make dx-mobile work with the latest version of flutter

### DIFF
--- a/lib/github/graphql.dart
+++ b/lib/github/graphql.dart
@@ -168,9 +168,9 @@ Future<int> getReleases(String owner, String repoName) async {
 
 // getPRs retrieves pull requests from a given repo/owner
 Future<List<PullRequest>> getPRs(String owner, String repoName) async {
-  final query = 
+  final query =
   '''
-  query { 
+  query {
     search (query: "type:pr state:open repo:$owner/$repoName", type: ISSUE, first: 100){
       edges {
         node {
@@ -183,7 +183,7 @@ Future<List<PullRequest>> getPRs(String owner, String repoName) async {
               login
             }
           }
-        } 
+        }
       }
     }
   }
@@ -195,9 +195,9 @@ Future<List<PullRequest>> getPRs(String owner, String repoName) async {
 
 // getIssues retrieves the open issues for a given repo
 Future<List<Issue>> getIssues(String owner, String repoName) async {
-  final query = 
+  final query =
   '''
-  query { 
+  query {
     search (query: "type:issue state:open repo:$owner/$repoName", type: ISSUE, first: 100){
       edges {
         node {
@@ -211,7 +211,7 @@ Future<List<Issue>> getIssues(String owner, String repoName) async {
               login
             }
           }
-        } 
+        }
       }
     }
   }
@@ -361,7 +361,7 @@ Future<List<Repository>> fetchUserRepos() async{
       login
       repositories(last:100) {
         nodes {
-          name 
+          name
           url
           nameWithOwner
         }

--- a/lib/pages/issuetimelineview.dart
+++ b/lib/pages/issuetimelineview.dart
@@ -77,7 +77,7 @@ class IssueTimelineViewState extends State<IssueTimelineView> {
               child: child);
         }),
       );
-      b = true;   
+      b = true;
       });
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,11 +4,14 @@ description: A new Flutter project.
 dependencies:
   flutter:
     sdk: flutter
-  http: "0.11.3+17"
-  font_awesome_flutter: ^7.0.0
-  bidirectional_scroll_view: ^0.0.5
+  font_awesome_flutter: ^8.1.0
   flutter_staggered_grid_view: "^0.2.2"
   pull_to_refresh: ^1.1.5
+  bidirectional_scroll_view:
+    # Until a new version of this plugin that works with Dart 2.0 is released,
+    # use this fork by a Googler.
+    git:
+      url: git://github.com/efortuna/flutter-bidirectional_scrollview_plugin.git
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
@@ -17,10 +20,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-
-dependency_overrides:
-  quiver: ^0.29.0
-  http: ^0.11.3
 
 
 # For information on the generic Dart part of this file, see the


### PR DESCRIPTION
# Summary
Flutter changes very quickly: There have been 1164 commits since version `0.5.1` :) . The longer we delay using a new version of Flutter, the harder it will become to upgrade. So I tried using Flutter 0.9.4 with this, and surprisingly, a few edits later, it works!

So here's what I changed:
 - Updated dependency declarations for some packages
 - Removed the version overrides for `http` and `quiver`. I had a look at the changelog for those packages, there doesn't seem to be any reason to keep using the old versions. The `http` package is already included with flutter, so I removed the dependency declaration altogether. 

If there was any reason for things being as they were previously, please let me know :D 

## Risks:
None that I'm aware of. I tested the app for the following: Repo List, Dashboard, Issue List, Issue page, adding a comment on the issue page.

I will create a follow-up issue to update README for instructions for flutter 0.9.4

### PS: My editor removed trailing whitespaces, I hope I don't need to create a separate PR for that :P