### PR TITLE
Update Flutter version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ For help getting started with Flutter, view our online
 [documentation](https://flutter.io/).
 
 ## Flutter Installation
-Please download this version of the Flutter SDK specifically - [v0.5.1](https://flutter.io/sdk-archive/)</br>
+Please download this version of the Flutter SDK specifically - [v0.9.4](https://flutter.io/sdk-archive/)</br>
 [Mac](https://flutter.io/setup-macos/) | [Windows](https://flutter.io/setup-windows/) | [Linux](https://flutter.io/setup-linux/)
 
 
 ## Setting it up
 
 You'll need:</br>
-    - installation of Flutter v0.5.1</br>
+    - installation of Flutter v0.9.4</br>
     - an emulator (Android or iOS)</br>
     - a GitHub API token (get yours [here](https://github.com/settings/tokens))</br>
     - cloned local copy of this repo</br>


### PR DESCRIPTION
# Summary

This is a suggestion for issue #18.

No team: Doing this as a part of my Hacktoberfest effort

Changed the Flutter version number in `README.md`.

## PR - Merge Checklist
- [ ] CR'd
- [ ] Workflow: Title has [semver](http://semver.org/) bump level defined (#major, #minor, or #patch)
- [ ] `.jenkins-docker` passes locally
- [x] README updated or N/A
- [ ] Acceptance criteria verified by QE
- [ ] Fully tested and approved by QE

## Dependencies
- [x] None

## Risks:

This is a documentation change. The only risk is that the document is confusing, and I doubt that would be the case.

Could not find other references to the previous version of Flutter.

## Rollback:

revert
