### PR TITLE
Add loading state to dashboard #patch 

### DIFF
--- a/lib/pages/dashboard.dart
+++ b/lib/pages/dashboard.dart
@@ -38,26 +38,22 @@ class _DashboardState extends State<Dashboard> {
   Future<List<Issue>> issueList;
   Future<int> branches;
   Future<int> releases;
+  static const LOADINGPLACEHOLDER = '…';
 
   RefreshController rc = RefreshController();
 
   @override
   void initState() {
-    prList = graphql.getPRs(widget.owner, widget.repoName);
-    issueList = graphql.getIssues(widget.owner, widget.repoName);
-    branches = graphql.getBranches(widget.owner, widget.repoName);
-    releases = graphql.getReleases(widget.owner, widget.repoName);
+    prList = widget.prList;
+    issueList = widget.issueList;
+    branches = widget.branches;
+    releases = widget.releases;
 
     super.initState();
   }
 
   @override
   Widget build(BuildContext context) {
-    prList = widget.prList;
-    issueList = widget.issueList;
-    branches = widget.branches;
-    releases = widget.releases;
-
     return Scaffold(
       appBar: _buildAppBar(),
       body: SmartRefresher(

--- a/lib/pages/dashboard.dart
+++ b/lib/pages/dashboard.dart
@@ -310,8 +310,14 @@ class _DashboardState extends State<Dashboard> {
   }
 
   Widget _buildPRText(BuildContext context, AsyncSnapshot<int> snapshot) {
+    String text = LOADINGPLACEHOLDER;
+
+    if (snapshot.connectionState == ConnectionState.done) {
+      text = '${snapshot.data}';
+    }
+
     return Text(
-      "${snapshot.data}",
+      text,
       style: TextStyle(
         color: Colors.black,
         fontWeight: FontWeight.w700,
@@ -321,8 +327,13 @@ class _DashboardState extends State<Dashboard> {
   }
 
   Widget _buildIssueText(BuildContext context, AsyncSnapshot<int> snapshot) {
+    String text = LOADINGPLACEHOLDER;
+
+    if (snapshot.connectionState == ConnectionState.done) {
+      text = '${snapshot.data}';
+    }
     return Text(
-      "${snapshot.data}",
+      text,
       style: TextStyle(
         color: Colors.black,
         fontWeight: FontWeight.w700,
@@ -340,14 +351,21 @@ class _DashboardState extends State<Dashboard> {
 
   Widget _buildFutureIntText(
       BuildContext context, AsyncSnapshot<int> snapshot) {
+    String text = LOADINGPLACEHOLDER;
+
+    if (snapshot.connectionState == ConnectionState.done) {
+      text = "${snapshot.data}";
+    }
+
     return Text(
-      "${snapshot.data}",
+      text,
       style: TextStyle(
         color: Colors.black,
         fontWeight: FontWeight.w700,
         fontSize: 34.0,
       ),
     );
+
   }
 
   void _refreshDashboard(bool b) {


### PR DESCRIPTION
# Summary
No team

This is a low priority PR but I thought it was worth making.
- Remove duplicate calls to graphql
- Add an [ellipses](https://www.compart.com/en/unicode/U+2026) on components that are using the `FutureBuilder` so `null` isn't shown before the future completes

## PR - Merge Checklist
- [ ] CR'd
- [ ] Workflow: Title has [semver](http://semver.org/) bump level defined (#major, #minor, or #patch)
- [ ] `.jenkins-docker` passes locally
- [ ] README updated or N/A
- [ ] Acceptance criteria verified by QE
- [ ] Fully tested and approved by QE

## Dependencies
N/A

## Risks:
I think this should be low risk. If there isn't a response from graphql the UI will be stuck with `…`, but it would also be stuck the `null` without this change. I also don't think there are other `ConnectionState`s that need to be accounted for in this case. I could be wrong though.

## Rollback:
{revert}

