### PR TITLE
#Minor Fix Link to LICENSE in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![SendGrid Logo](https://uiux.s3.amazonaws.com/2016-logos/email-logo%402x.png)</br>
-[![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE.txt)
+[![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE.md)
 
 # DX Mobile
 

--- a/README.md
+++ b/README.md
@@ -83,4 +83,4 @@ dx-mobile is maintained and funded by SendGrid, Inc. The names and logos for dx-
 
 <a name="license"></a>
 # License
-[The MIT License (MIT)](LICENSE.txt)
+[The MIT License (MIT)](LICENSE)


### PR DESCRIPTION
# Summary
The `README.md` file links to a `LICENSE.txt` file that is non-existent, thus results in a 404 error. This PR changes the Markdown link to point to the existing MIT `LICENSE` file (that doesn't have an extension)

## PR - Merge Checklist
- [x] CR'd
- [x] Workflow: Title has [semver](http://semver.org/) bump level defined (#major, #minor, or #patch)
- [x] `.jenkins-docker` passes locally
- [x] README updated or N/A
- [x] Acceptance criteria verified by QE
- [x] Fully tested and approved by QE

## Dependencies
- `README.md`

## Risks:
None really... broken links are bad. :man_shrugging: 

P.S. The `FIRST_TIMERS.md` file has a link to `CONTRIBUTING.md` [here](https://github.com/sendgrid/dx-mobile/blob/master/FIRST_TIMERS.md#important-notice) but no such file exists. I wasn't sure if it could be coppied from a different repo, so I didn't fix it in this PR, but just making you aware. :+1: 

